### PR TITLE
deleting getProjectionMatrix() from ARX_additions.js

### DIFF
--- a/Source/artoolkitx.js/ARX_additions.js
+++ b/Source/artoolkitx.js/ARX_additions.js
@@ -9,19 +9,6 @@ function _arrayToHeap(typedArray) {
     return heapBytes;
 }
 
-Module["getProjectionMatrix"] = function(nearPlane, farPlane) {
-    var projectionMatrix = new Float64Array(16);
-    var heapBytes = _arrayToHeap(projectionMatrix);
-
-    if( ! Module.ccall('arwGetProjectionMatrix', 'boolean',['number','number','number'], [nearPlane, farPlane, heapBytes.byteOffset])) {
-        return undefined;
-    }
-    var returnValue = new Float64Array(heapBytes);
-    Module._free(heapBytes.byteOffset);
-
-    return returnValue;
-};
-
 Module["getTrackablePatternConfig"] = function (trackableId, patternID) {
     var heapBytes = _arrayToHeap(new Float64Array(16));
     var widthHeapBytes = _arrayToHeap(new Float64Array(1));
@@ -47,7 +34,7 @@ Module["getTrackablePatternConfig"] = function (trackableId, patternID) {
 
     return returnObject;
 }
-    
+
 Module["getTrackablePatternImage"] = function (trackableId, patternID) {
 
     //Read trackable pattern config to get the size of the trackable. This is needed to define the Array size.

--- a/Source/artoolkitx.js/ARX_bindings.cpp
+++ b/Source/artoolkitx.js/ARX_bindings.cpp
@@ -21,14 +21,13 @@ EMSCRIPTEN_BINDINGS(constant_bindings) {
     function("arwStartRunningJS", &arwStartRunningJS);
     function("pushVideoInit", &pushVideoInit);
     function("getError", &arwGetError);
-    
+
     function("isRunning", &arwIsRunning);
     function("isInitialized", &arwIsInited);
     function("stopRunning", &arwStopRunning);
     function("shutdownAR", &arwShutdownAR);
 
     /*** Video stream management ***/
-    //* ATTENTION: arwGetProjectionMatrix is exported from ARX_additions.js
 
     value_object<VideoParams>("VideoParams")
         .field("width", &VideoParams::width)


### PR DESCRIPTION
As discussed in https://github.com/augmentmy-world/artoolkitX.js/pull/23 i remove the `getProjectionMatrix` from `ARX_additions.js`. In the future we will see what to do with `ARX_additions.js`


**p.s**.: in the commit i wrote `getCameraMatrix` but i mean `getProjectionMatrix`